### PR TITLE
Update token type to bearer

### DIFF
--- a/src/main/frontend/src/components/security/header.js
+++ b/src/main/frontend/src/components/security/header.js
@@ -2,5 +2,5 @@ import store from '../../store'
 
 export default () => {
   var keycloakAuth = store.getters.SECURITY_AUTH
-  return { 'Authorization': 'Bearer ' + keycloakAuth.idToken }
+  return { 'Authorization': 'Bearer ' + keycloakAuth.token }
 }


### PR DESCRIPTION
I tried implementing Keycloak, using example from here. I have a problem with Java Spring boot. After logging in (on the frontend) Keycloak returns token. After sending that token to the backend (Spring boot), I am getting an error "Token type is incorrect. Expected 'Bearer' but was 'ID'". After decoding token I see that in the "typ" there is "ID", but probably should be "bearer".

Token type is incorrect. Expected 'Bearer' but was 'ID'